### PR TITLE
Fix dark mode toggle button

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,17 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 
 const DarkModeToggle = () => {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+
+  useEffect(() => {
+    setTheme(resolvedTheme);
+  }, [resolvedTheme, setTheme]);
 
   const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
   };
 
   return (
     <Button onClick={toggleTheme}>
-      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+      {resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
     </Button>
   );
 };


### PR DESCRIPTION
Add functionality to the dark mode toggle button to make it work.

* **Sync theme state**: Add `useEffect` to sync theme state with `next-themes`.
* **Update button text**: Use `resolvedTheme` instead of `theme` for button text and theme toggling logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/3?shareId=122a6065-2502-4104-a386-80ad6e7cfabd).