### PR TITLE
Fix dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,15 @@
 .read-the-docs {
   color: #888;
 }
+
+/* Dark mode styles */
+@media (prefers-color-scheme: dark) {
+  .card {
+    background-color: var(--card);
+    color: var(--card-foreground);
+  }
+
+  .read-the-docs {
+    color: var(--muted-foreground);
+  }
+}

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,21 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 
 const DarkModeToggle = () => {
-  const { resolvedTheme, setTheme } = useTheme();
-
-  useEffect(() => {
-    setTheme(resolvedTheme);
-  }, [resolvedTheme, setTheme]);
+  const { theme, setTheme } = useTheme();
 
   const toggleTheme = () => {
-    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+    setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
   return (
     <Button onClick={toggleTheme}>
-      {resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
     </Button>
   );
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  darkMode: ["class"],
+  darkMode: 'class',
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
Add dark mode support to the application.

* **App.css**
  - Add dark mode styles for `.card` class to set background and text color.
  - Add dark mode styles for `.read-the-docs` class to set text color.

* **DarkModeToggle.tsx**
  - Remove `useEffect` hook.
  - Update `toggleTheme` function to use `theme` instead of `resolvedTheme`.
  - Update button text to use `theme` instead of `resolvedTheme`.

* **tailwind.config.ts**
  - Add `darkMode: 'class'` to enable class-based dark mode.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/4?shareId=5afcd660-3c1a-46f2-bd1c-e596cf8c02f3).