### PR TITLE
Fix dark mode button functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -66,4 +66,15 @@
   .login-page .read-the-docs {
     color: var(--muted-foreground);
   }
+
+  /* Dark mode styles for the #root element */
+  #root {
+    background-color: var(--background);
+    color: var(--foreground);
+  }
+
+  /* Dark mode styles for the .logo class */
+  .logo {
+    filter: drop-shadow(0 0 2em var(--primary));
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 const App = () => {
   return (
     <ThemeProvider defaultTheme="system">
+      <DarkModeToggle />
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <Toaster />

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -10,22 +10,6 @@ const DarkModeToggle = () => {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handleChange = (e: MediaQueryListEvent) => {
-      setTheme(e.matches ? 'dark' : 'light');
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-
-    // Set initial theme based on system preference
-    setTheme(mediaQuery.matches ? 'dark' : 'light');
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange);
-    };
-  }, [setTheme]);
-
   if (!mounted) return null;
 
   const toggleTheme = () => {


### PR DESCRIPTION
Add dark mode functionality to the application.

* **App Component**: Add `DarkModeToggle` component inside the `ThemeProvider` component in `src/App.tsx`.
* **DarkModeToggle Component**: Update `toggleTheme` function to use the `theme` state directly and remove the `useEffect` that sets the initial theme based on system preference in `src/components/DarkModeToggle.tsx`.
* **App CSS**: Add dark mode styles for the `#root` element and the `.logo` class in `src/App.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/10?shareId=96865a22-b0b6-49a3-ae16-f8151919c387).