### PR TITLE
Fix dark mode toggle button functionality

### DIFF
--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 
 const DarkModeToggle = () => {
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -11,14 +11,14 @@ const DarkModeToggle = () => {
   }, []);
 
   const toggleTheme = () => {
-    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+    setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
   if (!mounted) return null;
 
   return (
     <Button onClick={toggleTheme} className="ml-4">
-      {resolvedTheme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+      {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
     </Button>
   );
 };


### PR DESCRIPTION
Update the Dark Mode button functionality to use `theme` instead of `resolvedTheme`.

* **Toggle Theme Function**: Update the `toggleTheme` function to use `theme` instead of `resolvedTheme`.
* **Button Text**: Update the button text to use `theme` instead of `resolvedTheme`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/14?shareId=6cea3356-e6af-4d4d-95d6-d252c97ac8b8).