### PR TITLE
Fix Add Conversation button to create a new conversation

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -175,6 +175,7 @@ const Index = () => {
             onRename={handleRenameConversation}
             onDelete={handleDeleteConversation}
             onSelect={handleSelectConversation}
+            onClear={handleClearConversation}
           />
           <Button onClick={handleAddConversation}>Add Conversation</Button>
           <Button onClick={handleClearConversation}>Clear Conversation</Button>


### PR DESCRIPTION
Update the `ConversationMenu` component to include the `onClear` prop.

* Add the `onClear` prop to the `ConversationMenu` component in `src/pages/Index.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/20?shareId=884f0fc8-2bfe-4189-a889-fb6241390297).