### PR TITLE
Fix the API page and the DOC API page to be part of the website

### DIFF
--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const APIPage = () => {
+  return (
+    <div>
+      <h1>API Page</h1>
+      <p>This page provides information about the API.</p>
+    </div>
+  );
+};
+
+export default APIPage;

--- a/src/pages/DocAPIPage.tsx
+++ b/src/pages/DocAPIPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const DocAPIPage = () => {
+  return (
+    <div>
+      <h1>Documentation API Page</h1>
+      <p>This page provides information about the documentation API.</p>
+    </div>
+  );
+};
+
+export default DocAPIPage;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,9 +8,11 @@ import { createGeminiClient, generateResponse } from "@/utils/geminiClient";
 import { Button } from "@/components/ui/button";
 import { LogOut } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Routes, Route } from "react-router-dom";
 import DarkModeToggle from "@/components/DarkModeToggle";
 import ConversationMenu from "@/components/ConversationMenu";
+import APIPage from "./APIPage";
+import DocAPIPage from "./DocAPIPage";
 
 type Message = {
   role: "user" | "assistant" | "system";
@@ -182,12 +184,20 @@ const Index = () => {
         </aside>
 
         <main className="flex-1 overflow-y-auto p-4 space-y-4">
-          {messages.map((message, index) => (
-            <ChatMessage key={index} {...message} />
-          ))}
-          {isLoading && (
-            <ChatMessage role="assistant" content="" isLoading={true} />
-          )}
+          <Routes>
+            <Route path="/api" element={<APIPage />} />
+            <Route path="/doc-api" element={<DocAPIPage />} />
+            <Route path="/" element={
+              <>
+                {messages.map((message, index) => (
+                  <ChatMessage key={index} {...message} />
+                ))}
+                {isLoading && (
+                  <ChatMessage role="assistant" content="" isLoading={true} />
+                )}
+              </>
+            } />
+          </Routes>
         </main>
       </div>
 


### PR DESCRIPTION
Add API and Documentation API pages to the website.

* **Index.tsx**
  - Import `APIPage` and `DocAPIPage` components.
  - Add routes for `/api` and `/doc-api` paths.
  - Update the `Routes` component to include the new routes.

* **APIPage.tsx**
  - Create a new component `APIPage`.
  - Add a header with the title "API Page".
  - Add a paragraph with a brief description of the API.

* **DocAPIPage.tsx**
  - Create a new component `DocAPIPage`.
  - Add a header with the title "Documentation API Page".
  - Add a paragraph with a brief description of the documentation API.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/21?shareId=189fb85e-a2cc-42ae-8ac3-2114a3f941d8).