### PR TITLE
Fix API key page layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Index from "./pages/Index";
 import Login from "./pages/Login";
 import { ThemeProvider } from "next-themes";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import APIPage from "./pages/APIPage";
 
 const queryClient = new QueryClient();
 
@@ -48,6 +49,14 @@ const App = () => {
                 element={
                   <ProtectedRoute>
                     <Index />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/api"
+                element={
+                  <ProtectedRoute>
+                    <APIPage />
                   </ProtectedRoute>
                 }
               />

--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -1,10 +1,31 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const APIPage = () => {
   return (
-    <div>
-      <h1>API Page</h1>
-      <p>This page provides information about the API.</p>
+    <div className="main-layout">
+      <header className="header">
+        <Link to="/" className="logo">
+          <img src="/logo.png" alt="Logo" />
+        </Link>
+        <nav className="menu">
+          <ul>
+            <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
+              <Link to="/api">API</Link>
+            </li>
+            <li>
+              <Link to="/doc-api">Documentation API</Link>
+            </li>
+          </ul>
+        </nav>
+      </header>
+      <main>
+        <h1>API Page</h1>
+        <p>This page provides information about the API.</p>
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
Integrate the API key page into the main website layout.

* **APIPage.tsx**
  - Import `Link` from `react-router-dom`.
  - Add logo and menu components to the page.
  - Wrap the content with a main layout div.

* **App.tsx**
  - Import `APIPage` component.
  - Add a route for the API key page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yosi2377/chatgemsphere/pull/23?shareId=d0edbdaf-29cf-4c14-8455-be75f2847270).